### PR TITLE
footerの無限ループ現象を修正

### DIFF
--- a/workspace/apps/brochure/modules/playground/templates/footerSuccess.php
+++ b/workspace/apps/brochure/modules/playground/templates/footerSuccess.php
@@ -31,5 +31,3 @@
     </li>
   </ul>
 </div>
-<?php //フッターメニュー ?>
-<?php include('footerSuccess.php'); ?>


### PR DESCRIPTION
## 起こっていたこと
* http://localhost:8080/playgroundひらけない問題
* メモリーが足りてないよとエラーが起きているのを確認

## なぜ起きていたか
* workspace/apps/brochure/modules/playground/templates/footerSuccess.php L:35
``` workspace/apps/brochure/modules/playground/templates/footerSuccess.php
<?php include('footerSuccess.php'); ?>
```
** footerSuccess.phpの中からfooterSuccess.phpを呼び出していることにより無限ループが発生
** 処理を終えきれずメモリ不足のエラー

## 解消方法
* 上記記述を削除
* @fussy113のlocal環境で動作確認